### PR TITLE
Fixed missing file error in alpaka package

### DIFF
--- a/packages/alpaka/package.py
+++ b/packages/alpaka/package.py
@@ -49,7 +49,7 @@ class Alpaka(Package):
         install('CMakeLists.txt', prefix)
         install('Findalpaka.cmake', prefix)
         # awww
-        for troll in [".gitignore", ".travis.yml", ".zenodo.json", "appveyor.yml", "COPYING", "COPYING.LESSER", "README.md"]:
+        for troll in [".gitignore", ".travis.yml", ".zenodo.json", ".appveyor.yml", "COPYING", "COPYING.LESSER", "README.md"]:
             install(troll, prefix)
 
     #def setup_dependent_environment(self, spack_env, run_env, dependent_spec):


### PR DESCRIPTION
Installing alpaka resulted in an error because `appveyor.yml` could not be found. In the alpaka repo its name currently is `.appveyor.yml` instead.