### PR TITLE
Fixed alpaka install error

### DIFF
--- a/packages/alpaka/package.py
+++ b/packages/alpaka/package.py
@@ -51,7 +51,7 @@ class Alpaka(Package):
         install('CMakeLists.txt', prefix)
         install('Findalpaka.cmake', prefix)
         # awww
-        for troll in [".gitignore", ".travis.yml", ".zenodo.json", ".appveyor.yml", "COPYING", "COPYING.LESSER", "README.md"]:
+        for troll in [".gitignore", ".travis.yml", ".zenodo.json", "COPYING", "COPYING.LESSER", "README.md"]:
             install(troll, prefix)
 
     #def setup_dependent_environment(self, spack_env, run_env, dependent_spec):


### PR DESCRIPTION
`.appveyor.yml` has been removed since https://github.com/ComputationalRadiationPhysics/alpaka/commit/8d0a3f42b25b69d455dc910620ff77edc1ce1400 but the install script still has a reference to it which makes new installations of alpaka fail on hemera. I removed the reference to the non-existing file.