### PR TITLE
Fix a typo in sourcing PIC_COMP_FILE for PIConGPU

### DIFF
--- a/packages/picongpu/picongpu.profile
+++ b/packages/picongpu/picongpu.profile
@@ -11,5 +11,5 @@ spack load -r @PIC_SPACK_SPEC@
 # activate bash completion if available
 PIC_COMP_FILE=$PICSRC/bin/picongpu-completion.bash
 if [ -f $PIC_COMP_FILE ] ; then
-    source PIC_COMP_FILE
+    source $PIC_COMP_FILE
 fi


### PR DESCRIPTION
The typo was introduced at 29d1c13 / #5.

Was spotted during investigation of https://github.com/ComputationalRadiationPhysics/picongpu/issues/3264 , however seems to be not the only problem there.