### PR TITLE
PIConGPU: OpenMPI 4.0.1+ OK

### DIFF
--- a/packages/picongpu/package.py
+++ b/packages/picongpu/package.py
@@ -78,9 +78,7 @@ class Picongpu(Package):
     depends_on('zlib@1.2.11')
     depends_on('boost@1.62.0:1.70.0 cxxstd=11')
     depends_on('boost@1.65.1:1.70.0 cxxstd=11', when='backend=cuda ^cuda@9:')
-    # note: NOT cuda aware!
-    # depends_on('mpi@2.3:', type=['link', 'run'])
-    depends_on('openmpi@1.8:3.99,4.0.1:', type=['link', 'run'])
+    depends_on('mpi@2.3:', type=['link', 'run'])  # note: NOT cuda aware!
     depends_on('pngwriter@0.7.0,develop', when='+png')
     depends_on('libsplash@1.7.0,develop', when='+hdf5')
     depends_on('adios@1.13.1:,develop', when='+adios')

--- a/packages/picongpu/package.py
+++ b/packages/picongpu/package.py
@@ -80,7 +80,7 @@ class Picongpu(Package):
     depends_on('boost@1.65.1:1.70.0 cxxstd=11', when='backend=cuda ^cuda@9:')
     # note: NOT cuda aware!
     # depends_on('mpi@2.3:', type=['link', 'run'])
-    depends_on('openmpi@1.8:3.99', type=['link', 'run'])
+    depends_on('openmpi@1.8:3.99,4.0.1:', type=['link', 'run'])
     depends_on('pngwriter@0.7.0,develop', when='+png')
     depends_on('libsplash@1.7.0,develop', when='+hdf5')
     depends_on('adios@1.13.1:,develop', when='+adios')


### PR DESCRIPTION
Allow newer OpenMPI releases that provide the compatibility layer to build well with packages such as HDF5...

See:
- https://github.com/spack/spack/blob/v0.15.4/var/spack/repos/builtin/packages/openmpi/package.py#L504-L508
- https://github.com/open-mpi/ompi/issues/6114#issuecomment-446279495