### PR TITLE
update ISAAC and PIConGPU recipes

### DIFF
--- a/packages/isaac-server/arm.patch
+++ b/packages/isaac-server/arm.patch
@@ -1,0 +1,18 @@
+diff -ru spack-src/server/CMakeLists.txt spack-src.new/server/CMakeLists.txt
+--- spack-src/server/CMakeLists.txt	2018-06-12 23:00:55.000000000 +0900
++++ spack-src.new/server/CMakeLists.txt	2019-07-16 19:05:23.842478919 +0900
+@@ -84,7 +84,13 @@
+ 	add_definitions(-DISAAC_JPEG)
+ endif (ISAAC_JPEG)
+ 
+-add_definitions(-std=c++11 -march=native -mtune=native)
++if (CMAKE_SYSTEM_PROCESSOR STREQUAL aarch64 AND
++    CMAKE_C_COMPILER_ID STREQUAL GNU AND
++    CMAKE_C_COMPILER_VERSION VERSION_LESS 6.0)
++    add_definitions(-std=c++11)
++else ()
++    add_definitions(-std=c++11 -march=native -mtune=native)
++endif ()
+ 
+ add_executable(isaac ${HDRS} ${SRCS})
+ 

--- a/packages/isaac-server/jpeg.patch
+++ b/packages/isaac-server/jpeg.patch
@@ -1,0 +1,34 @@
+diff --git a/server/src/Broker.cpp b/server/src/Broker.cpp
+index 03d60f4..aab449f 100644
+--- a/server/src/Broker.cpp
++++ b/server/src/Broker.cpp
+@@ -108,14 +108,14 @@ MetaDataClient* Broker::addDataClient()
+ 	}
+ 	boolean isaac_jpeg_fill_input_buffer(j_decompress_ptr cinfo)
+ 	{
+-		return true;
++		return TRUE;
+ 	}
+ 	void isaac_jpeg_skip_input_data(j_decompress_ptr cinfo,long num_bytes)
+ 	{
+ 	}
+ 	boolean isaac_jpeg_resync_to_restart(j_decompress_ptr cinfo, int desired)
+ 	{
+-		return true;
++		return TRUE;
+ 	}
+ 	void isaac_jpeg_term_source(j_decompress_ptr cinfo)
+ 	{
+diff --git a/server/src/URIImageConnector.cpp b/server/src/URIImageConnector.cpp
+index 0b11800..e843aa4 100644
+--- a/server/src/URIImageConnector.cpp
++++ b/server/src/URIImageConnector.cpp
+@@ -40,7 +40,7 @@ void isaac_init_destination(j_compress_ptr cinfo)
+ }
+ boolean isaac_jpeg_empty_output_buffer(j_compress_ptr cinfo)
+ {
+-	return true;
++	return TRUE;
+ }
+ void isaac_jpeg_term_destination(j_compress_ptr cinfo)
+ {

--- a/packages/isaac-server/package.py
+++ b/packages/isaac-server/package.py
@@ -1,0 +1,44 @@
+# Copyright 2013-2021 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class IsaacServer(CMakePackage):
+    """In Situ Animation of Accelerated Computations: Server"""
+
+    homepage = "http://computationalradiationphysics.github.io/isaac/"
+    url      = "https://github.com/ComputationalRadiationPhysics/isaac/archive/v1.3.0.tar.gz"
+    git      = "https://github.com/ComputationalRadiationPhysics/isaac.git"
+
+    maintainers = ['ax3l']
+
+    version('develop', branch='dev')
+    version('master', branch='master')
+    version('1.5.2', sha256='9cedd72bea06f387b697b17a0db076e50fb3b85b74f21d3a6d99ed0d664a9ef2')
+    version('1.5.1', sha256='f62d53aa6e1c28e51437dbf3d1ac0daa2f98d28660f09feaabcc953ff01b076e')
+    version('1.5.0', sha256='4d5a150dfe064289d760da368102172f84e9e8851a177c8125a56e151db58dce')
+    version('1.4.0', sha256='6cbd4cc54a22de5e5a3427e44141db6e7b80b33fe7a0c707390a113655bf344e')
+    version('1.3.3', sha256='92a972d05d315ad66546671c047b7edf8ed0e05d64d2b8d77ababb5bb9b93d8e')
+    version('1.3.2', sha256='e6eedc641de5b0a7c5ea5cda6b11e9b6d4a78dfac8be90302147b26d09859a68')
+    version('1.3.1', sha256='7dead8f3d5467cbd2cde8187e7b860a4ab7796348895d18291f97a76e28757cf')
+    version('1.3.0', sha256='fcf10f4738e7790ef6604e1e2cdd052a129ba4e53a439deaafa9fb2a70585574')
+
+    # variant('gstreamer', default=False, description= \
+    #         'Support for RTP streams, e.g. to Twitch or Youtube')
+
+    depends_on('cmake@3.3:', type='build')
+    depends_on('jpeg', type='link')
+    depends_on('jansson@:2.9', type='link', when='@:1.5.1')
+    depends_on('jansson', type='link')
+    depends_on('boost@1.56.0:', type='link')
+    depends_on('libwebsockets@2.1.1:', type='link')
+    # depends_on('gstreamer@1.0', when='+gstreamer')
+
+    # https://github.com/ComputationalRadiationPhysics/isaac/pull/70
+    patch('jpeg.patch', when='@:1.3.1')
+    patch('arm.patch', when='@:1.4.0 target=aarch64:')
+
+    root_cmakelists_dir = 'server'

--- a/packages/isaac/package.py
+++ b/packages/isaac/package.py
@@ -31,14 +31,16 @@ class Isaac(CMakePackage):
     # variant('alpaka', default=False,
     #         description='Generate kernels via Alpaka, for CPUs or GPUs')
 
-    depends_on('cmake@3.3:', type='build')
+    depends_on('cmake@3.3:', type='build', when='@:1.5.2')
+    depends_on('cmake@3.15:', type='build')
     depends_on('jpeg', type='link')
     depends_on('jansson', type='link')
     depends_on('boost@1.56.0:', type='link')
     depends_on('boost@1.65.1:', type='link', when='^cuda@9:')
-    depends_on('cuda@7.0:', type='link', when='+cuda')
+    depends_on('cuda@7.0:', type='link', when='@:1.5.2 +cuda')
     # depends_on('alpaka@0.3', when='+alpaka')
     depends_on('icet', type='link')
     depends_on('mpi', type='link')
+    depends_on('glm@0.9.9.8:', when='@develop')
 
     root_cmakelists_dir = 'lib'

--- a/packages/isaac/package.py
+++ b/packages/isaac/package.py
@@ -1,0 +1,44 @@
+# Copyright 2013-2021 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class Isaac(CMakePackage):
+    """In Situ Animation of Accelerated Computations: Header-Only Library"""
+
+    homepage = "http://computationalradiationphysics.github.io/isaac/"
+    url      = "https://github.com/ComputationalRadiationPhysics/isaac/archive/v1.3.0.tar.gz"
+    git      = "https://github.com/ComputationalRadiationPhysics/isaac.git"
+
+    maintainers = ['ax3l']
+
+    version('develop', branch='dev')
+    version('master', branch='master')
+    version('1.5.2', sha256='9cedd72bea06f387b697b17a0db076e50fb3b85b74f21d3a6d99ed0d664a9ef2')
+    version('1.5.1', sha256='f62d53aa6e1c28e51437dbf3d1ac0daa2f98d28660f09feaabcc953ff01b076e')
+    version('1.5.0', sha256='4d5a150dfe064289d760da368102172f84e9e8851a177c8125a56e151db58dce')
+    version('1.4.0', sha256='6cbd4cc54a22de5e5a3427e44141db6e7b80b33fe7a0c707390a113655bf344e')
+    version('1.3.3', sha256='92a972d05d315ad66546671c047b7edf8ed0e05d64d2b8d77ababb5bb9b93d8e')
+    version('1.3.2', sha256='e6eedc641de5b0a7c5ea5cda6b11e9b6d4a78dfac8be90302147b26d09859a68')
+    version('1.3.1', sha256='7dead8f3d5467cbd2cde8187e7b860a4ab7796348895d18291f97a76e28757cf')
+    version('1.3.0', sha256='fcf10f4738e7790ef6604e1e2cdd052a129ba4e53a439deaafa9fb2a70585574')
+
+    variant('cuda', default=True,
+            description='Generate CUDA kernels for Nvidia GPUs')
+    # variant('alpaka', default=False,
+    #         description='Generate kernels via Alpaka, for CPUs or GPUs')
+
+    depends_on('cmake@3.3:', type='build')
+    depends_on('jpeg', type='link')
+    depends_on('jansson', type='link')
+    depends_on('boost@1.56.0:', type='link')
+    depends_on('boost@1.65.1:', type='link', when='^cuda@9:')
+    depends_on('cuda@7.0:', type='link', when='+cuda')
+    # depends_on('alpaka@0.3', when='+alpaka')
+    depends_on('icet', type='link')
+    depends_on('mpi', type='link')
+
+    root_cmakelists_dir = 'lib'

--- a/packages/picongpu/package.py
+++ b/packages/picongpu/package.py
@@ -60,9 +60,11 @@ class Picongpu(Package):
     variant('png', default=True,
             description='Enable the PNG plugin')
     variant('hdf5', default=True,
-            description='Enable multiple plugins requiring HDF5')
+            description='Enable multiple plugins requiring HDF5,'
+                        '(only available for <=0.5.X)')
     variant('adios', default=False,
-            description='Enable the ADIOS plugin')
+            description='Enable the ADIOS plugin,'
+                        '(only available for <=0.5.X)')
     variant('isaac', default=False,
             description='Enable the ISAAC plugin')
     variant('openpmd',
@@ -83,12 +85,14 @@ class Picongpu(Package):
     depends_on('boost@1.65.1:1.70.0 cxxstd=11', when='backend=cuda ^cuda@9:')
     depends_on('mpi@2.3:', type=['link', 'run'])  # note: NOT cuda aware!
     depends_on('pngwriter@0.7.0,develop', when='+png')
-    depends_on('libsplash@1.7.0,develop', when='+hdf5')
-    depends_on('adios@1.13.1:,develop', when='+adios')
+    depends_on('libsplash@1.7.0,develop', when='@:0.5.0 +hdf5')
+    depends_on('adios@1.13.1:,develop', when='@:0.5.0 +adios')
     depends_on('isaac@1.4.0', when='@:0.4.3 +isaac')
+    depends_on('isaac@1.5.2', when='@:0.5.0 +isaac')
+    depends_on('isaac@develop', when='@develop +isaac')
     depends_on('isaac-server@1.4.0', type='run', when='@:0.4.3 +isaac')
-    depends_on('isaac@1.5.2,develop', when='@0.5.0: +isaac')
-    depends_on('isaac-server@1.5.2,develop', type='run', when='@0.5.0: +isaac')
+    depends_on('isaac-server@1.5.2', type='run', when='@:0.5.0 +isaac')
+    depends_on('isaac-server@develop', type='run', when='@develop +isaac')
     depends_on('openpmd-api@0.13.2:,dev', when='@develop +openpmd')
 
     # shipped internal dependencies


### PR DESCRIPTION
Updating spack recipes take a long until they are available in a stable spack release, this provides an issue for the user because they can mostly not pull the spack develop branch.
The ISAAC spack recipes will be pushed from time to time to the spack mainline.

To see the changes in the ISAAC recipes compared to the spack mainline check the last commit only.

- PIConGPU:
  - disable dependency HDF5 and adios for the develop branch
- ISAAC:
  - add dependency glm for the develop branch

# Test

I tested the recipe with PIConGPU, as soon as https://github.com/ComputationalRadiationPhysics/isaac/pull/150 is merged PIConGPU + ISAAC docker container build for the dev branch should work.